### PR TITLE
switch to idiomatic constructor pattern

### DIFF
--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -4,8 +4,8 @@ import (
 	"os"
 	"testing"
 
-	config "github.com/kyallanum/athena/v1.0.0/models/config"
-	logs "github.com/kyallanum/athena/v1.0.0/models/logs"
+	config "github.com/kyallanum/athena/models/config"
+	logs "github.com/kyallanum/athena/models/logs"
 )
 
 func TestResolveFile(t *testing.T) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"os"
 
-	config "github.com/kyallanum/athena/v1.0.0/models/config"
-	library "github.com/kyallanum/athena/v1.0.0/models/library"
-	logs "github.com/kyallanum/athena/v1.0.0/models/logs"
+	config "github.com/kyallanum/athena/models/config"
+	library "github.com/kyallanum/athena/models/library"
+	logs "github.com/kyallanum/athena/models/logs"
 	"github.com/spf13/cobra"
 )
 
@@ -36,7 +36,7 @@ func Execute() error {
 	}
 
 	err := rootCmd.Execute()
-  errCheck(err)
+	errCheck(err)
 	fmt.Println("Athena v1.0.0 Starting")
 
 	fmt.Println("Getting Configuration File: ", configFile, "...")
@@ -78,7 +78,7 @@ func resolveLogFile(contents *logs.LogFile, configuration *config.Configuration)
 		return nil, fmt.Errorf("configuration does not have any rules")
 	}
 
-	ret_library := library.Library.New(library.Library{}, configuration.Name)
+	ret_library := library.New(configuration.Name)
 
 	fmt.Println("Resolving Log File")
 	for i := 0; i < len(configuration.Rules); i++ {

--- a/go.mod
+++ b/go.mod
@@ -2,11 +2,13 @@ module github.com/kyallanum/athena
 
 go 1.21
 
-require github.com/davidmytton/url-verifier v1.0.0
+require (
+	github.com/davidmytton/url-verifier v1.0.0
+	github.com/spf13/cobra v1.8.0
+)
 
 require (
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/kyallanum/athena/v1.0.0
+module github.com/kyallanum/athena
 
 go 1.21
 

--- a/main.go
+++ b/main.go
@@ -6,9 +6,9 @@ import (
 	"os"
 
 	"github.com/kyallanum/athena/cmd"
-	"github.com/kyallanum/athena/models/config"
-	"github.com/kyallanum/athena/models/library"
-	"github.com/kyallanum/athena/models/logs"
+	config "github.com/kyallanum/athena/models/config"
+	library "github.com/kyallanum/athena/models/library"
+	logs "github.com/kyallanum/athena/models/logs"
 )
 
 func errCheck(err error) {

--- a/main.go
+++ b/main.go
@@ -1,11 +1,110 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"os"
 
-	"github.com/kyallanum/athena/v1.0.0/cmd"
+	"github.com/kyallanum/athena/cmd"
+	"github.com/kyallanum/athena/models/config"
+	"github.com/kyallanum/athena/models/library"
+	"github.com/kyallanum/athena/models/logs"
 )
+
+func errCheck(err error) {
+	if err != nil {
+		panic(err)
+	}
+}
+
+func parseFlags(configFile *string, logFile *string) error {
+	var configFlag string
+	var logFlag string
+
+	flag.StringVar(&configFlag, "c", "", "")
+	flag.StringVar(&configFlag, "config", "", "")
+	flag.StringVar(&logFlag, "l", "", "")
+	flag.StringVar(&logFlag, "log-file", "", "")
+	flag.Parse()
+
+	if *configFile == "" {
+		*configFile = configFlag
+	}
+	if *logFile == "" {
+		*logFile = logFlag
+	}
+
+	if *configFile == "" {
+		return fmt.Errorf("configuration file was not specified")
+	}
+
+	if *logFile == "" {
+		return fmt.Errorf("log file was not specified")
+	}
+
+	return nil
+}
+
+func resolveLogFile(contents *logs.LogFile, configuration *config.Configuration) (*library.Library, error) {
+	wrapError := func(err error) error {
+		return fmt.Errorf("unable to resolve log file: \n\t%w", err)
+	}
+
+	if contents == nil || contents.Len() == 0 {
+		return nil, fmt.Errorf("log file contains no contents")
+	} else if configuration == nil || (configuration.Name == "" && configuration.Rules == nil) {
+		return nil, fmt.Errorf("configuration file has no contents")
+	} else if configuration.Name == "" {
+		return nil, fmt.Errorf("configuration file contains no log name")
+	} else if configuration.Rules == nil || len(configuration.Rules) == 0 {
+		return nil, fmt.Errorf("configuration does not have any rules")
+	}
+
+	ret_library := library.New(configuration.Name)
+
+	fmt.Println("Resolving Log File")
+	for i := 0; i < len(configuration.Rules); i++ {
+		currentRuleData, err := config.ResolveRule(contents, &configuration.Rules[i])
+		if err != nil {
+			return nil, wrapError(err)
+		}
+
+		ret_library.AddRuleData(configuration.Rules[i].Name, currentRuleData)
+	}
+
+	fmt.Println("Log File Resolved")
+
+	return ret_library, nil
+}
+
+func printSummary(library *library.Library) error {
+	wrapError := func(err error) error {
+		return fmt.Errorf("unable to print summary: \n\t%w", err)
+	}
+
+	libraryName, err := library.Name()
+	if err != nil {
+		return wrapError(err)
+	}
+
+	fmt.Printf("\n--------------- %s Log File Summary ---------------\n", libraryName)
+	libraryKeys := library.LibraryKeys()
+	for _, rule := range libraryKeys {
+		fmt.Printf("Rule: %s\n", rule)
+		ruleData, _ := library.RuleData(rule)
+		summaryDataLen := ruleData.SummaryDataLen()
+		if summaryDataLen == 0 {
+			fmt.Println("No summary lines provided.")
+		} else {
+			for i := 0; i < summaryDataLen; i++ {
+				fmt.Println("\t", ruleData.SummaryData(i))
+			}
+		}
+		fmt.Println()
+	}
+
+	return nil
+}
 
 func main() {
 	defer func() {

--- a/models/config/configuration_test.go
+++ b/models/config/configuration_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	logs "github.com/kyallanum/athena/v1.0.0/models/logs"
+	logs "github.com/kyallanum/athena/models/logs"
 )
 
 func TestTranslateRegex(t *testing.T) {

--- a/models/config/regex_utils.go
+++ b/models/config/regex_utils.go
@@ -5,7 +5,7 @@ import (
 	"regexp"
 	"strings"
 
-	library "github.com/kyallanum/athena/v1.0.0/models/library"
+	library "github.com/kyallanum/athena/models/library"
 )
 
 // func resolveLine determines whether the current log line matches a

--- a/models/config/regex_utils_test.go
+++ b/models/config/regex_utils_test.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	library "github.com/kyallanum/athena/v1.0.0/models/library"
+	library "github.com/kyallanum/athena/models/library"
 )
 
 func TestResolveLine(t *testing.T) {
@@ -52,7 +52,7 @@ func TestTranslateSearchTermReference(t *testing.T) {
 	}()
 
 	regex := `Testing {{test}}`
-	st_data := library.SearchTermData.New(library.SearchTermData{})
+	st_data := library.NewSearchTermData()
 	st_data.AddValue("test", "Test1")
 
 	newRegex, err := translateSearchTermReference(regex, st_data)
@@ -73,7 +73,7 @@ func TestTranslateSearchTermReferenceBadReference(t *testing.T) {
 	}()
 
 	regex := `Testing {{test}}`
-	st_data := library.SearchTermData.New(library.SearchTermData{})
+	st_data := library.NewSearchTermData()
 	st_data.AddValue("bad_test", "testing")
 
 	_, err := translateSearchTermReference(regex, st_data)

--- a/models/config/rule_utils.go
+++ b/models/config/rule_utils.go
@@ -3,8 +3,8 @@ package models
 import (
 	"fmt"
 
-	library "github.com/kyallanum/athena/v1.0.0/models/library"
-	logs "github.com/kyallanum/athena/v1.0.0/models/logs"
+	library "github.com/kyallanum/athena/models/library"
+	logs "github.com/kyallanum/athena/models/logs"
 )
 
 func ResolveRule(contents *logs.LogFile, rule *Rule) (*library.RuleData, error) {
@@ -15,7 +15,7 @@ func ResolveRule(contents *logs.LogFile, rule *Rule) (*library.RuleData, error) 
 	allEntriesFound := false
 	linesResolved := []int{}
 
-	currentRuleData := library.RuleData.New(library.RuleData{})
+	currentRuleData := library.NewRuleData()
 
 	for !allEntriesFound {
 		currentSearchTermData, err := resolveSearchTerms(contents, rule, &linesResolved)

--- a/models/config/searchterm_utils.go
+++ b/models/config/searchterm_utils.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"slices"
 
-	library "github.com/kyallanum/athena/v1.0.0/models/library"
-	logs "github.com/kyallanum/athena/v1.0.0/models/logs"
+	library "github.com/kyallanum/athena/models/library"
+	logs "github.com/kyallanum/athena/models/logs"
 )
 
 func resolveSearchTerms(logFile *logs.LogFile, rule *Rule, linesResolved *[]int) (*library.SearchTermData, error) {
@@ -19,7 +19,7 @@ func resolveSearchTerms(logFile *logs.LogFile, rule *Rule, linesResolved *[]int)
 		}
 	}()
 
-	currentSearchTermData := library.SearchTermData.New(library.SearchTermData{})
+	currentSearchTermData := library.NewSearchTermData()
 	currentSearchTerm := rule.SearchTerms[0]
 	searchTermTranslated := false
 	for fileIndex, searchTermIndex := 0, 0; fileIndex < logFile.Len() && searchTermIndex < len(rule.SearchTerms); fileIndex++ {

--- a/models/config/source_config.go
+++ b/models/config/source_config.go
@@ -75,7 +75,7 @@ func Source(source string) (IConfigurationSource, error) {
 	}
 
 	if isUrl {
-		return ConfigWebSource.New(ConfigWebSource{}, source), nil
+		return NewWebSource(source), nil
 	}
 
 	isFile, err := verifyFilePath(source)
@@ -84,7 +84,7 @@ func Source(source string) (IConfigurationSource, error) {
 	}
 
 	if isFile {
-		return ConfigFileSource.New(ConfigFileSource{}, source), nil
+		return NewFileSource(source), nil
 	}
 
 	//Should never reach this

--- a/models/config/source_config_test.go
+++ b/models/config/source_config_test.go
@@ -15,7 +15,7 @@ func TestGetSourceFile(t *testing.T) {
 		t.Errorf("Error returned from getSource when it shouldn't have: \n\t%s", err.Error())
 	}
 
-	if reflect.TypeOf(configSource).String() != "*models.ConfigFileSource" {
+	if reflect.TypeOf(configSource).String() != "*models.FileSource" {
 		t.Errorf("Correct data type not returned from GetSource")
 	}
 }
@@ -42,7 +42,7 @@ func TestGetSourceWeb(t *testing.T) {
 		t.Errorf("Error returned from getSource when it shouldn't have: \n\t%s", err.Error())
 	}
 
-	if reflect.TypeOf(configWeb).String() != "*models.ConfigWebSource" {
+	if reflect.TypeOf(configWeb).String() != "*models.WebSource" {
 		t.Errorf("Correct data type not returned from GetSource: \n\t%s", reflect.TypeOf(configWeb).String())
 	}
 }

--- a/models/config/source_file.go
+++ b/models/config/source_file.go
@@ -7,11 +7,11 @@ import (
 	"path/filepath"
 )
 
-type ConfigFileSource struct {
+type FileSource struct {
 	ConfigurationSource
 }
 
-func (config *ConfigFileSource) Config() ([]byte, error) {
+func (config *FileSource) Config() ([]byte, error) {
 	wrapError := func(err error) error {
 		return fmt.Errorf("unable to load configuration from file: \n\t%w", err)
 	}
@@ -48,8 +48,8 @@ func (config *ConfigFileSource) Config() ([]byte, error) {
 	return bytes, nil
 }
 
-func (ConfigFileSource) New(source string) IConfigurationSource {
-	return &ConfigFileSource{
+func NewFileSource(source string) IConfigurationSource {
+	return &FileSource{
 		ConfigurationSource: ConfigurationSource{
 			source_type: "file",
 			source:      source,

--- a/models/config/source_file_test.go
+++ b/models/config/source_file_test.go
@@ -15,7 +15,7 @@ func TestNewFileConfig(t *testing.T) {
 		t.Errorf("Configuration source type not set properly")
 	}
 
-	if reflect.TypeOf(fileSource).String() != "*models.ConfigFileSource" {
+	if reflect.TypeOf(fileSource).String() != "*models.FileSource" {
 		t.Errorf("Configuration source not of the right type")
 	}
 }

--- a/models/config/source_file_test.go
+++ b/models/config/source_file_test.go
@@ -9,7 +9,7 @@ import (
 func TestNewFileConfig(t *testing.T) {
 	source := "./examples/apt-term-config.json"
 
-	fileSource := ConfigFileSource.New(ConfigFileSource{}, source)
+	fileSource := NewFileSource(source)
 
 	if fileSource.SourceType() != "file" {
 		t.Errorf("Configuration source type not set properly")
@@ -22,7 +22,7 @@ func TestNewFileConfig(t *testing.T) {
 
 func TestLoadFileConfig(t *testing.T) {
 	source := "../../examples/apt-term-config.json"
-	fileSource := ConfigFileSource.New(ConfigFileSource{}, source)
+	fileSource := NewFileSource(source)
 
 	fileConfig, err := fileSource.Config()
 	if err != nil {

--- a/models/config/source_web.go
+++ b/models/config/source_web.go
@@ -6,11 +6,11 @@ import (
 	"net/http"
 )
 
-type ConfigWebSource struct {
+type WebSource struct {
 	ConfigurationSource
 }
 
-func (config *ConfigWebSource) Config() ([]byte, error) {
+func (config *WebSource) Config() ([]byte, error) {
 	wrapError := func(err error) error {
 		return fmt.Errorf("unable to create configuration for web source: \n\t%w", err)
 	}
@@ -30,8 +30,8 @@ func (config *ConfigWebSource) Config() ([]byte, error) {
 	return data, nil
 }
 
-func (ConfigWebSource) New(source string) IConfigurationSource {
-	return &ConfigWebSource{
+func NewWebSource(source string) IConfigurationSource {
+	return &WebSource{
 		ConfigurationSource: ConfigurationSource{
 			source_type: "web",
 			source:      source,

--- a/models/config/source_web_test.go
+++ b/models/config/source_web_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestNewWebSource(t *testing.T) {
-	configSource := ConfigFileSource.New(ConfigFileSource{}, "../../examples/apt-term-config.json")
+	configSource := NewWebSource("../../examples/apt-term-config.json")
 	configFileString, _ := configSource.Config()
 
 	testTable := []struct {
@@ -27,12 +27,12 @@ func TestNewWebSource(t *testing.T) {
 	}
 
 	for _, testServer := range testTable {
-		testWebSource := ConfigWebSource.New(ConfigWebSource{}, testServer.server.URL)
+		testWebSource := NewWebSource(testServer.server.URL)
 		if testWebSource.SourceType() != "web" {
 			t.Errorf("Config source type not set properly.")
 		}
 
-		if reflect.TypeOf(testWebSource).String() != "*models.ConfigWebSource" {
+		if reflect.TypeOf(testWebSource).String() != "*models.WebSource" {
 			t.Errorf("Config source not of the right type.")
 		}
 	}
@@ -40,7 +40,7 @@ func TestNewWebSource(t *testing.T) {
 }
 
 func TestLoadWebConfig(t *testing.T) {
-	configSource := ConfigFileSource.New(ConfigFileSource{}, "../../examples/apt-term-config.json")
+	configSource := NewFileSource("../../examples/apt-term-config.json")
 	configFileString, _ := configSource.Config()
 
 	testTable := []struct {
@@ -71,7 +71,7 @@ func TestLoadWebConfig(t *testing.T) {
 	for _, testServer := range testTable {
 		t.Run(testServer.name, func(t *testing.T) {
 			defer testServer.server.Close()
-			testWebSource := ConfigWebSource.New(ConfigWebSource{}, testServer.server.URL)
+			testWebSource := NewWebSource(testServer.server.URL)
 			configFileString, err := testWebSource.Config()
 
 			if reflect.TypeOf(configFileString).String() != reflect.TypeOf(testServer.expectedOutput).String() {

--- a/models/config/summary_utils.go
+++ b/models/config/summary_utils.go
@@ -6,7 +6,7 @@ import (
 	"slices"
 	"strings"
 
-	library "github.com/kyallanum/athena/v1.0.0/models/library"
+	library "github.com/kyallanum/athena/models/library"
 )
 
 func summaryKeys(summaryLine string) [][]string {

--- a/models/library/library.go
+++ b/models/library/library.go
@@ -10,7 +10,7 @@ type Library struct {
 	name                 string
 }
 
-func (Library) New(name string) *Library {
+func New(name string) *Library {
 	return &Library{
 		rule_data_collection: make(map[string]RuleData),
 		name:                 name,

--- a/models/library/library_test.go
+++ b/models/library/library_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestLibraryGetName(t *testing.T) {
-	current_library := Library.New(Library{}, "test_stuff")
+	current_library := New("test_stuff")
 	library_name, err := current_library.Name()
 	if err != nil {
 		t.Errorf("an error occurred when getting name for library")
@@ -18,7 +18,7 @@ func TestLibraryGetName(t *testing.T) {
 }
 
 func TestLibraryGetNameNoName(t *testing.T) {
-	current_library := Library.New(Library{}, "")
+	current_library := New("")
 	_, err := current_library.Name()
 
 	if err == nil {
@@ -31,10 +31,10 @@ func TestLibraryGetNameNoName(t *testing.T) {
 }
 
 func TestGetLibraryKeys(t *testing.T) {
-	ruleData1 := RuleData.New(RuleData{})
-	ruleData2 := RuleData.New(RuleData{})
+	ruleData1 := NewRuleData()
+	ruleData2 := NewRuleData()
 
-	library := Library.New(Library{}, "test_library")
+	library := New("test_library")
 	library.AddRuleData("ruleData1", &ruleData1)
 	library.AddRuleData("ruleData2", &ruleData2)
 
@@ -50,7 +50,7 @@ func TestGetLibraryKeys(t *testing.T) {
 }
 
 func TestGetLibraryKeysNoKeys(t *testing.T) {
-	library := Library.New(Library{}, "testing")
+	library := New("testing")
 
 	libraryKeys := library.LibraryKeys()
 
@@ -60,9 +60,9 @@ func TestGetLibraryKeysNoKeys(t *testing.T) {
 }
 
 func TestGetRuleData(t *testing.T) {
-	ruleData1 := RuleData.New(RuleData{})
+	ruleData1 := NewRuleData()
 
-	library := Library.New(Library{}, "testing")
+	library := New("testing")
 	library.AddRuleData("ruleData1", &ruleData1)
 
 	newRuleData, err := library.RuleData("ruleData1")
@@ -76,7 +76,7 @@ func TestGetRuleData(t *testing.T) {
 }
 
 func TestGetRuleDataNoKeys(t *testing.T) {
-	library := Library.New(Library{}, "testing")
+	library := New("testing")
 
 	_, err := library.RuleData("testingData")
 
@@ -86,9 +86,9 @@ func TestGetRuleDataNoKeys(t *testing.T) {
 }
 
 func TestAddRuleData(t *testing.T) {
-	ruleData1 := RuleData.New(RuleData{})
+	ruleData1 := NewRuleData()
 
-	library := Library.New(Library{}, "testing")
+	library := New("testing")
 	err := library.AddRuleData("ruleData1", &ruleData1)
 
 	if err != nil {
@@ -97,10 +97,10 @@ func TestAddRuleData(t *testing.T) {
 }
 
 func TestAddRuleDataOverwrite(t *testing.T) {
-	ruleData1 := RuleData.New(RuleData{})
-	ruleData2 := RuleData.New(RuleData{})
+	ruleData1 := NewRuleData()
+	ruleData2 := NewRuleData()
 
-	library := Library.New(Library{}, "testing")
+	library := New("testing")
 	library.AddRuleData("ruleData1", &ruleData1)
 	err := library.AddRuleData("ruleData1", &ruleData2)
 

--- a/models/library/operation_count.go
+++ b/models/library/operation_count.go
@@ -36,7 +36,7 @@ func (count *Count) CalculateOperation(ruleData RuleData) ([]string, error) {
 	return ret_value, nil
 }
 
-func (Count) New(key string) ISummaryOperation {
+func NewCountOperation(key string) ISummaryOperation {
 	return &Count{
 		SummaryOperation: SummaryOperation{
 			operation: "count",

--- a/models/library/operation_count_test.go
+++ b/models/library/operation_count_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestCreateNewCount(t *testing.T) {
-	testCountOperation := Count.New(Count{}, "test")
+	testCountOperation := NewCountOperation("test")
 
 	if testCountOperation.Operation() != "count" {
 		t.Errorf("Operation type is not correct for count.")
@@ -18,17 +18,17 @@ func TestCreateNewCount(t *testing.T) {
 }
 
 func TestCountCalculateOperation(t *testing.T) {
-	st_data1 := SearchTermData.New(SearchTermData{})
+	st_data1 := NewSearchTermData()
 	st_data1.AddValue("test", "testing 1")
 
-	st_data2 := SearchTermData.New(SearchTermData{})
+	st_data2 := NewSearchTermData()
 	st_data2.AddValue("test", "testing 2")
 
-	testRuleData := RuleData.New(RuleData{})
+	testRuleData := NewRuleData()
 	testRuleData.AppendSearchTermData(st_data1)
 	testRuleData.AppendSearchTermData(st_data2)
 
-	testCountOperation := Count.New(Count{}, "test")
+	testCountOperation := NewCountOperation("test")
 
 	numTests, err := testCountOperation.CalculateOperation(testRuleData)
 
@@ -46,8 +46,8 @@ func TestCountCalculateOperation(t *testing.T) {
 }
 
 func TestCountCalculateOperationEmptyRuleData(t *testing.T) {
-	testRuleData := RuleData.New(RuleData{})
-	testCountOperation := Count.New(Count{}, "test")
+	testRuleData := NewRuleData()
+	testCountOperation := NewCountOperation("test")
 	_, err := testCountOperation.CalculateOperation(testRuleData)
 
 	if err.Error() != "rule does not have any search term data stored" {
@@ -56,13 +56,13 @@ func TestCountCalculateOperationEmptyRuleData(t *testing.T) {
 }
 
 func TestCountCalculateOperationSearchTermNotExist(t *testing.T) {
-	st_data1 := SearchTermData.New(SearchTermData{})
+	st_data1 := NewSearchTermData()
 	st_data1.AddValue("bad_test", "testing")
 
-	testRuleData := RuleData.New(RuleData{})
+	testRuleData := NewRuleData()
 	testRuleData.AppendSearchTermData(st_data1)
 
-	testCountOperation := Count.New(Count{}, "test")
+	testCountOperation := NewCountOperation("test")
 	_, err := testCountOperation.CalculateOperation(testRuleData)
 	if err.Error() != "this value was never extracted during search phase" {
 		t.Errorf("Error not returned properly for search term data that was never created")

--- a/models/library/operation_factory.go
+++ b/models/library/operation_factory.go
@@ -37,9 +37,9 @@ func (summaryKey *SummaryOperation) SetKey(key string) {
 func Operation(operation string, key string) (ISummaryOperation, error) {
 	switch strings.ToLower(strings.TrimSpace(operation)) {
 	case "count":
-		return Count.New(Count{}, key), nil
+		return NewCountOperation(key), nil
 	case "print":
-		return Print.New(Print{}, key), nil
+		return NewPrintOperation(key), nil
 	}
 
 	return nil, fmt.Errorf("the given operation is not implemented: %s\n\t", operation)

--- a/models/library/operation_print.go
+++ b/models/library/operation_print.go
@@ -30,7 +30,7 @@ func (print *Print) CalculateOperation(ruleData RuleData) ([]string, error) {
 	return ret_value, nil
 }
 
-func (Print) New(key string) ISummaryOperation {
+func NewPrintOperation(key string) ISummaryOperation {
 	return &Print{
 		SummaryOperation: SummaryOperation{
 			operation: "print",

--- a/models/library/operation_print_test.go
+++ b/models/library/operation_print_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestCreateNewPrint(t *testing.T) {
-	testPrint := Print.New(Print{}, "testing")
+	testPrint := NewPrintOperation("testing")
 
 	if testPrint.Operation() != "print" {
 		t.Errorf("Returned object does not have the right operation")
@@ -18,17 +18,17 @@ func TestCreateNewPrint(t *testing.T) {
 }
 
 func TestPrintCalculateOperation(t *testing.T) {
-	st_data1 := SearchTermData.New(SearchTermData{})
+	st_data1 := NewSearchTermData()
 	st_data1.AddValue("testing", "test 1")
 
-	st_data2 := SearchTermData.New(SearchTermData{})
+	st_data2 := NewSearchTermData()
 	st_data2.AddValue("testing", "test 2")
 
-	testRuleData := RuleData.New(RuleData{})
+	testRuleData := NewRuleData()
 	testRuleData.AppendSearchTermData(st_data1)
 	testRuleData.AppendSearchTermData(st_data2)
 
-	testOperation := Print.New(Print{}, "testing")
+	testOperation := NewPrintOperation("testing")
 	printOutput, err := testOperation.CalculateOperation(testRuleData)
 	if err != nil {
 		t.Errorf("An error occurred when attempting to resolve lines to print: \n\t%s", err.Error())
@@ -44,8 +44,8 @@ func TestPrintCalculateOperation(t *testing.T) {
 }
 
 func TestPrintCalculateOperationEmptyRuleData(t *testing.T) {
-	testRuleData := RuleData.New(RuleData{})
-	testPrintOperation := Print.New(Print{}, "testing")
+	testRuleData := NewRuleData()
+	testPrintOperation := NewPrintOperation("testing")
 
 	_, err := testPrintOperation.CalculateOperation(testRuleData)
 	if err.Error() != "rule does not have any search term data stored" {
@@ -54,13 +54,13 @@ func TestPrintCalculateOperationEmptyRuleData(t *testing.T) {
 }
 
 func TestPrintCalculateOperationSearchTermNotExist(t *testing.T) {
-	st_data1 := SearchTermData.New(SearchTermData{})
+	st_data1 := NewSearchTermData()
 	st_data1.AddValue("bad_test", "test 1")
 
-	testRuleData := RuleData.New(RuleData{})
+	testRuleData := NewRuleData()
 	testRuleData.AppendSearchTermData(st_data1)
 
-	testPrintOperation := Print.New(Print{}, "testing")
+	testPrintOperation := NewPrintOperation("testing")
 	_, err := testPrintOperation.CalculateOperation(testRuleData)
 
 	if err.Error() != "this value was never extracted during search phase" {

--- a/models/library/ruledata.go
+++ b/models/library/ruledata.go
@@ -8,7 +8,7 @@ type RuleData struct {
 	summary_data       []string
 }
 
-func (RuleData) New() RuleData {
+func NewRuleData() RuleData {
 	return RuleData{
 		st_data_collection: []SearchTermData{},
 	}

--- a/models/library/searchtermdata.go
+++ b/models/library/searchtermdata.go
@@ -10,7 +10,7 @@ type SearchTermData struct {
 	data map[string]string
 }
 
-func (SearchTermData) New() *SearchTermData {
+func NewSearchTermData() *SearchTermData {
 	return &SearchTermData{
 		data: make(map[string]string),
 	}

--- a/models/library/searchtermdata_test.go
+++ b/models/library/searchtermdata_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestCreateNewSearchTermData(t *testing.T) {
-	st_data := SearchTermData.New(SearchTermData{})
+	st_data := NewSearchTermData()
 
 	if reflect.TypeOf(st_data).String() != "*models.SearchTermData" {
 		t.Errorf("Creating new SearchTermData returned the wrong type")
@@ -14,7 +14,7 @@ func TestCreateNewSearchTermData(t *testing.T) {
 }
 
 func TestSearchTermDataGetKeys(t *testing.T) {
-	st_data := SearchTermData.New(SearchTermData{})
+	st_data := NewSearchTermData()
 	st_data.AddValue("test1", "testing")
 	st_data.AddValue("test2", "testing")
 
@@ -30,7 +30,7 @@ func TestSearchTermDataGetKeys(t *testing.T) {
 }
 
 func TestSearchTermDataGetKeysNoKeys(t *testing.T) {
-	st_data := SearchTermData.New(SearchTermData{})
+	st_data := NewSearchTermData()
 
 	keys_returned := st_data.Keys()
 
@@ -40,7 +40,7 @@ func TestSearchTermDataGetKeysNoKeys(t *testing.T) {
 }
 
 func TestGetValue(t *testing.T) {
-	st_data := SearchTermData.New(SearchTermData{})
+	st_data := NewSearchTermData()
 	st_data.AddValue("test1", "testing")
 
 	currentValue, err := st_data.Value("test1")
@@ -58,7 +58,7 @@ func TestGetValue(t *testing.T) {
 }
 
 func TestGetValueWrongValue(t *testing.T) {
-	st_data := SearchTermData.New(SearchTermData{})
+	st_data := NewSearchTermData()
 
 	_, err := st_data.Value("test1")
 
@@ -72,7 +72,7 @@ func TestGetValueWrongValue(t *testing.T) {
 }
 
 func TestAddValue(t *testing.T) {
-	st_data := SearchTermData.New(SearchTermData{})
+	st_data := NewSearchTermData()
 
 	err := st_data.AddValue("test1", "testing")
 	if err != nil {

--- a/models/logs/logfile.go
+++ b/models/logs/logfile.go
@@ -24,7 +24,7 @@ func (logfile *LogFile) LineAtIndex(index int) (string, error) {
 	return logfile.contents[index], nil
 }
 
-func (LogFile) New(contents []string) *LogFile {
+func New(contents []string) *LogFile {
 	return &LogFile{
 		contents: contents,
 		length:   len(contents),
@@ -53,6 +53,6 @@ func LoadLogFile(fileName string) (*LogFile, error) {
 		return nil, wrapError(err)
 	}
 
-	logFileContents := LogFile.New(LogFile{}, lines)
+	logFileContents := New(lines)
 	return logFileContents, nil
 }

--- a/models/logs/logfile_test.go
+++ b/models/logs/logfile_test.go
@@ -18,7 +18,7 @@ func TestGetLineAtIndex(t *testing.T) {
 		logFile = append(logFile, currentText)
 	}
 
-	logFileObject := LogFile.New(LogFile{}, logFile)
+	logFileObject := New(logFile)
 
 	line, err := logFileObject.LineAtIndex(0)
 	if err != nil {


### PR DESCRIPTION
This project currently uses the following constructor pattern in several places:

```golang
type StructType struct{}

func (StructType) New() *StructType {
        return &StructType{}
}
``` 

This results in construction looking like this in packages outside the models package:

```golang
v := pkgname.StructType.New(pkgname.StructType{})
```

This change converts constructors to a more idomatic style.

```golang
type StructType struct{}

func NewStructType() *StructType {
        return &StructType{}
}
```

This results in a more straight forward construction of types.

```golang
v := pkgname.NewStructType()
```